### PR TITLE
fix(deps): patch security vulnerabilities in picomatch and uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
     "chokidar": "^3.6.0",
     "debounce": "^2.1.0",
     "p-retry": "^6.2.0",
-    "picomatch": "^4.0.2",
+    "picomatch": "^4.0.4",
     "pino": "^9.2.0",
     "pino-pretty": "^11.2.1",
-    "uuid": "^10.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "picomatch@<2.3.2": "^2.3.2"
+    }
   },
   "packageManager": "pnpm@9.4.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  picomatch@<2.3.2: ^2.3.2
+
 importers:
 
   .:
@@ -18,8 +21,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       picomatch:
-        specifier: ^4.0.2
-        version: 4.0.2
+        specifier: ^4.0.4
+        version: 4.0.4
       pino:
         specifier: ^9.2.0
         version: 9.2.0
@@ -27,8 +30,8 @@ importers:
         specifier: ^11.2.1
         version: 11.2.1
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@vercel/ncc':
         specifier: ^0.38.1
@@ -165,12 +168,12 @@ packages:
     resolution: {integrity: sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==}
     engines: {node: '>=16.17'}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pino-abstract-transport@1.2.0:
@@ -247,8 +250,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   wrappy@1.0.2:
@@ -267,7 +270,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   atomic-sleep@1.0.0: {}
 
@@ -363,9 +366,9 @@ snapshots:
       is-network-error: 1.1.0
       retry: 0.13.1
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.2: {}
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@1.2.0:
     dependencies:
@@ -426,7 +429,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   real-require@0.2.0: {}
 
@@ -458,6 +461,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  uuid@10.0.0: {}
+  uuid@14.0.0: {}
 
   wrappy@1.0.2: {}


### PR DESCRIPTION
- picomatch 4.0.2 → 4.0.4 (ReDoS + method injection, GHSA-c2c7-rcm5-vvqj / GHSA-3v7f-55p6-f55p)
- uuid 10.0.0 → 14.0.0 (buffer bounds check, GHSA-w5hq-g745-h8pq)